### PR TITLE
Feature/native api calls

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,5 @@
+flake8:
+  enabled: true
+
+python:
+  enabled: true

--- a/.hound.yml
+++ b/.hound.yml
@@ -3,3 +3,5 @@ flake8:
 
 python:
   enabled: true
+
+fail_on_violations: true

--- a/README.md
+++ b/README.md
@@ -4,68 +4,13 @@ speedcopy
 [![Build Status](https://travis-ci.com/antirotor/speedcopy.svg?branch=master)](https://travis-ci.com/antirotor/speedcopy)
 [![PyPI version](https://badge.fury.io/py/speedcopy.svg)](https://badge.fury.io/py/speedcopy)
 
-Patched python shutil.copyfile using xcopy on windows to accelerate transfer on windows shares.
+Patched python shutil.copyfile using native call CopyFileW on windows to accelerate
+transfer on windows shares. On Linux, it issues special ioctl command `CIFS_IOC_COPYCHUNK_FILE` to enable server-side copy.
 
-Using ``xcopy`` on windows to server-side copy on network shares where enabled.
+This works only when both files are on same SMB1(CIFS)/2/3 filesystem.
 
 See https://wiki.samba.org/index.php/Server-Side_Copy
 
-It is based on `pyfastcopy` so it should accelerate copying on linux too.
+Benchmark timings to come ...
 
-Those are benchmark values based on my local setup:
-
-Windows copy / local storage
-----------------------------
-
-| filesize (mb) | python | copy  |
-|--------------:|-------:|------:|
-| 1             | 0.003  | 0.067 |
-| 2             | 0.005  | 0.067 |
-| 4             | 0.010  | 0.068 |
-| 8             | 0.020  | 0.073 |
-| 16            | 0.042  | 0.079 |
-| 32            | 0.088  | 0.092 |
-| 64            | 1.925  | 1.200 |
-| 128           | 0.366  | 0.169 |
-| 256           | 0.754  | 0.277 |
-| 512           | 1.622  | 0.505 |
-| 1024          | 3.567  | 0.910 |
-| 2048          | 7.242  | 2.607 |
-
-Windows xcopy / local storage
------------------------------
-
-| filesize (mb) | python | xcopy |
-|--------------:|-------:|------:|
-| 1             | 0.003  | 0.135 |
-| 2             | 0.005  | 0.134 |
-| 4             | 0.010  | 0.136 |
-| 8             | 0.019  | 0.140 |
-| 6             | 0.039  | 0.144 |
-| 32            | 0.087  | 0.158 |
-| 64            | 1.884  | 1.858 |
-| 128           | 0.360  | 0.240 |
-| 256           | 0.774  | 0.335 |
-| 512           | 1.612  | 0.561 |
-| 1024          | 3.575  | 1.199 |
-| 2048          | 6.864  | 2.599 |
-
-Windows xcopy / samba share
----------------------------
-
-| filesize (mb) | python | xcopy  |
-|--------------:|-------:|-------:|
-| 1             | 0.070  | 0.153  |
-| 2             | 0.144  | 0.157  |
-| 4             | 0.298  | 0.163  |
-| 8             | 0.623  | 0.167  |
-| 16            | 1.181  | 0.176  |
-| 32            | 2.385  | 0.195  |
-| 64            | 49.040 | 2.437  |
-| 128           | 8.846  | 0.306  |
-| 256           | 17.135 | 2.954  |
-| 512           | 30.407 | 4.422  |
-| 1024          | 55.591 | 30.331 |
-| 2048          | 105.003| 204.680|
-
-There are some spikes I attribute to working load on system I was running benchmark on. You can test it yourself with included `benchmark.py`
+You can test it yourself with included `benchmark.py` (and this will take some time as values are measured multiple times).

--- a/benchmark.py
+++ b/benchmark.py
@@ -45,9 +45,15 @@ if __name__ == "__main__":
                         repeat=5
                         )
                     v = min(v)
-                    dp = str(v / (10 if file_size_mb >= 64 else 100))
-                    print("  - Speed: {}".format(dp))
-                    datapoint.append(dp)
+                    dp = v / (10 if file_size_mb >= 64 else 100)
+                    if not use_fast_copy:
+                        raw_dp = dp
+                        print("  - Speed: {}".format(dp))
+                    else:
+                        speed_up = raw_dp / dp
+                        print("  - Speed: {}".format(dp))
+                        print("  - Speedup: {}x".format(round(speed_up, 2)))
+                    datapoint.append(str(dp))
                     try:
                         os.remove(dst)
                     except FileNotFoundError:

--- a/speedcopy/__init__.py
+++ b/speedcopy/__init__.py
@@ -123,7 +123,7 @@ if not sys.platform.startswith("win32"):
             os.symlink(os.readlink(src), dst)
         else:
             CIFS_IOCTL_MAGIC = 0xCF
-            CIFS_IOC_COPYCHUNK_FILE = IOW(CIFS_IOCTL_MAGIC, 3, c_int)
+            CIFS_IOC_COPYCHUNK_FILE = IOW(CIFS_IOCTL_MAGIC.value, 3, c_int)
             with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
                 # try copy file with COW support on Linux. If fail, fallback
                 # to sendfile and if this is not available too, fallback

--- a/speedcopy/__init__.py
+++ b/speedcopy/__init__.py
@@ -11,6 +11,7 @@ from .fstatfs import FilesystemInfo
 
 SPEEDCOPY_DEBUG = False
 
+
 def debug(msg):
     if SPEEDCOPY_DEBUG:
         print(msg)
@@ -137,13 +138,14 @@ if not sys.platform.startswith("win32"):
             os.symlink(os.readlink(src), dst)
         else:
             fs_src_type = FilesystemInfo().filesystem(src.encode('utf-8'))
-            fs_dst_type = FilesystemInfo().filesystem(os.path.dirname(dst.encode('utf-8')))
+            fs_dst_type = FilesystemInfo().filesystem(
+                os.path.dirname(dst.encode('utf-8')))
             supported_fs = ['CIFS', 'SMB2']
             debug(">>> Source FS: {}".format(fs_src_type))
             debug(">>> Destination FS: {}".format(fs_dst_type))
             if fs_src_type in supported_fs and fs_dst_type in supported_fs:
                 fsrc = os.open(src, os.O_RDONLY)
-                fdst = os.open(dst, os.O_WRONLY|os.O_CREAT)
+                fdst = os.open(dst, os.O_WRONLY | os.O_CREAT)
 
                 CIFS_IOCTL_MAGIC = 0xCF
                 CIFS_IOC_COPYCHUNK_FILE = IOW(CIFS_IOCTL_MAGIC, 3, c_int)

--- a/speedcopy/__init__.py
+++ b/speedcopy/__init__.py
@@ -188,7 +188,6 @@ else:
         It uses windows native CopyFileW method to do so, making advantage of
         server-side copy where available.
         """
-        from ctypes import wintypes
 
         if shutil._samefile(src, dst):
             # Get shutil.SameFileError if available (Python 3.4+)

--- a/speedcopy/__init__.py
+++ b/speedcopy/__init__.py
@@ -188,7 +188,7 @@ else:
         It uses windows native CopyFileW method to do so, making advantage of
         server-side copy where available.
         """
-        # from ctypes import wintypes
+        from ctypes import wintypes
 
         if shutil._samefile(src, dst):
             # Get shutil.SameFileError if available (Python 3.4+)
@@ -231,6 +231,11 @@ else:
 
             if ret != 0:
                 error = ctypes.get_last_error()
+                # 997 is ERROR_IO_PENDING. Why it is poping here with
+                # CopyFileW is beyond me, but  assume we can easily
+                # ignore it as it is copying nevertheless
+                if error == 997:
+                    return dst
                 raise IOError(
                     "File {!r} copy failed, error: {}".format(src, error))
         return dst

--- a/speedcopy/__init__.py
+++ b/speedcopy/__init__.py
@@ -17,6 +17,7 @@ if not sys.platform.startswith("win32"):
         _sendfile = sendfile.sendfile
     from fcntl import ioctl
     import ctypes
+    from ctypes import c_int
 
     _IOC_NRBITS = 8
     _IOC_TYPEBITS = 8
@@ -122,7 +123,7 @@ if not sys.platform.startswith("win32"):
             os.symlink(os.readlink(src), dst)
         else:
             CIFS_IOCTL_MAGIC = 0xCF
-            CIFS_IOC_COPYCHUNK_FILE = IOW(CIFS_IOCTL_MAGIC, 3, int)
+            CIFS_IOC_COPYCHUNK_FILE = IOW(CIFS_IOCTL_MAGIC, 3, c_int)
             with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
                 # try copy file with COW support on Linux. If fail, fallback
                 # to sendfile and if this is not available too, fallback

--- a/speedcopy/__init__.py
+++ b/speedcopy/__init__.py
@@ -213,11 +213,11 @@ else:
         else:
             kernel32 = ctypes.WinDLL('kernel32',
                                      use_last_error=True, use_errno=True)
-            copyfile = kernel32.CopyFileW
+            copyfile = kernel32.CopyFile2
             copyfile.argtypes = (ctypes.c_wchar_p,
                                  ctypes.c_wchar_p,
-                                 ctypes.wintypes.BOOL)
-            copyfile.restype = ctypes.wintypes.BOOL
+                                 ctypes.c_void_p)
+            copyfile.restype = ctypes.HRESULT
 
             source_file = os.path.normpath(src)
             dest_file = os.path.normpath(dst)
@@ -227,10 +227,12 @@ else:
                 dest_file = 'UNC\\' + dest_file[2:]
 
             ret = copyfile('\\\\?\\' + source_file,
-                           '\\\\?\\' + dest_file, True)
+                           '\\\\?\\' + dest_file, None)
 
             if ret != 0:
                 error = ctypes.get_last_error()
+                if error == 0:
+                    return dst
                 # 997 is ERROR_IO_PENDING. Why it is poping here with
                 # CopyFileW is beyond me, but  assume we can easily
                 # ignore it as it is copying nevertheless

--- a/speedcopy/__init__.py
+++ b/speedcopy/__init__.py
@@ -7,7 +7,6 @@ import os
 import shutil
 import stat
 import sys
-from .fstatfs import FilesystemInfo
 
 SPEEDCOPY_DEBUG = False
 
@@ -27,6 +26,7 @@ if not sys.platform.startswith("win32"):
     import ctypes
     import ctypes.util
     from ctypes import c_int
+    from .fstatfs import FilesystemInfo
 
     CIFS_MAGIC_NUMBER = 0xFF534D42
     SMB2_MAGIC_NUMBER = 0xFE534D42

--- a/speedcopy/__init__.py
+++ b/speedcopy/__init__.py
@@ -182,12 +182,12 @@ else:
         It uses windows native CopyFileW method to do so, making advantage of
         server-side copy where available.
         """
-        from ctypes import windll, c_wchar_p, c_int
+        from ctypes import wintypes
 
-        kernel32 = windll.kernel32
-        copy_file_w = kernel32.CopyFileW
-        copy_file_w.argtypes = (c_wchar_p, c_wchar_p, c_int)
-        copy_file_w.restype = c_int
+        # kernel32 = windll.kernel32
+        # copy_file_w = kernel32.CopyFileW
+        # copy_file_w.argtypes = (c_wchar_p, c_wchar_p, c_int)
+        # copy_file_w.restype = c_int
 
         if shutil._samefile(src, dst):
             # Get shutil.SameFileError if available (Python 3.4+)
@@ -210,7 +210,12 @@ else:
         if not follow_symlinks and os.path.islink(src):
             os.symlink(os.readlink(src), dst)
         else:
-            ret = copy_file_w(src, dst, False)
+            kernel32 = ctypes.windll.kernel32
+            kernel32.CopyFileW.restype = wintypes.BOOL
+
+            ret = kernel32.CopyFileW(ctypes.c_wchar_p(src),
+                                     ctypes.c_wchar_p(dst),
+                                     wintypes.BOOL(True))
 
             if ret != 0:
                 raise IOError(

--- a/speedcopy/__init__.py
+++ b/speedcopy/__init__.py
@@ -123,12 +123,12 @@ if not sys.platform.startswith("win32"):
             os.symlink(os.readlink(src), dst)
         else:
             CIFS_IOCTL_MAGIC = 0xCF
-            CIFS_IOC_COPYCHUNK_FILE = IOW(CIFS_IOCTL_MAGIC.value, 3, c_int)
+            CIFS_IOC_COPYCHUNK_FILE = IOW(CIFS_IOCTL_MAGIC, 3, c_int)
             with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
                 # try copy file with COW support on Linux. If fail, fallback
                 # to sendfile and if this is not available too, fallback
                 # copyfileobj.
-                ret = ioctl(fdst, CIFS_IOC_COPYCHUNK_FILE, fsrc)
+                ret = ioctl(fdst, CIFS_IOC_COPYCHUNK_FILE.value, fsrc)
                 if ret != 0:
                     # Try to use sendfile if available for performance
                     if not _copyfile_sendfile(fsrc, fdst):

--- a/speedcopy/fstatfs.py
+++ b/speedcopy/fstatfs.py
@@ -1,0 +1,163 @@
+"""
+python fstatfs implementation taken from:
+https://github.com/mithro/rcfiles
+"""
+import os
+import ctypes
+import ctypes.util
+
+
+libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+
+
+class Fs_types():
+    # Constants for filesystem magic
+    # https://www.gnu.org/software/coreutils/filesystems.html
+    ADFS_SUPER_MAGIC       = 0xadf5
+    AFFS_SUPER_MAGIC       = 0xADFF
+    BEFS_SUPER_MAGIC       = 0x42465331
+    BFS_MAGIC              = 0x1BADFACE
+    CIFS_MAGIC_NUMBER      = 0xFF534D42
+    CODA_SUPER_MAGIC       = 0x73757245
+    COH_SUPER_MAGIC        = 0x012FF7B7
+    CRAMFS_MAGIC           = 0x28cd3d45
+    DEVFS_SUPER_MAGIC      = 0x1373
+    EFS_SUPER_MAGIC        = 0x00414A53
+    EXT_SUPER_MAGIC        = 0x137D
+    EXT2_OLD_SUPER_MAGIC   = 0xEF51
+    EXT2_SUPER_MAGIC       = 0xEF53
+    EXT3_SUPER_MAGIC       = 0xEF53
+    HFS_SUPER_MAGIC        = 0x4244
+    HPFS_SUPER_MAGIC       = 0xF995E849
+    HUGETLBFS_MAGIC        = 0x958458f6
+    ISOFS_SUPER_MAGIC      = 0x9660
+    JFFS2_SUPER_MAGIC      = 0x72b6
+    JFS_SUPER_MAGIC        = 0x3153464a
+    MINIX_SUPER_MAGIC      = 0x137F # orig. minix
+    MINIX_SUPER_MAGIC2     = 0x138F # 30 char minix
+    MINIX2_SUPER_MAGIC     = 0x2468 # minix V2
+    MINIX2_SUPER_MAGIC2    = 0x2478 # minix V2, 30 char names
+    MSDOS_SUPER_MAGIC      = 0x4d44
+    NCP_SUPER_MAGIC        = 0x564c
+    NFS_SUPER_MAGIC        = 0x6969
+    NTFS_SB_MAGIC          = 0x5346544e
+    OPENPROM_SUPER_MAGIC   = 0x9fa1
+    PROC_SUPER_MAGIC       = 0x9fa0
+    QNX4_SUPER_MAGIC       = 0x002f
+    REISERFS_SUPER_MAGIC   = 0x52654973
+    ROMFS_MAGIC            = 0x7275
+    SMB_SUPER_MAGIC        = 0x517B
+    SYSV2_SUPER_MAGIC      = 0x012FF7B6
+    SYSV4_SUPER_MAGIC      = 0x012FF7B5
+    TMPFS_MAGIC            = 0x01021994
+    UDF_SUPER_MAGIC        = 0x15013346
+    UFS_MAGIC              = 0x00011954
+    USBDEVICE_SUPER_MAGIC  = 0x9fa2
+    VXFS_SUPER_MAGIC       = 0xa501FCF5
+    XENIX_SUPER_MAGIC      = 0x012FF7B4
+    XFS_SUPER_MAGIC        = 0x58465342
+    _XIAFS_SUPER_MAGIC     = 0x012FD16D
+
+    types = {}
+
+    def __init__(self):
+
+        for name in self.__dict__:
+            if name.endswith('MAGIC'):
+                hname = name[:-6]
+                hname = hname.replace('_SUPER', '')
+                _types[eval(name)] = hname
+
+
+class statfs_t(ctypes.Structure):
+  """
+  Describes the details about a filesystem.
+
+  f_type:    type of file system (see below)
+  f_bsize:   optimal transfer block size
+  f_blocks:  total data blocks in file system
+  f_bfree:   free blocks in fs
+  f_bavail:  free blocks avail to non-superuser
+  f_files:   total file nodes in file system
+  f_ffree:   free file nodes in fs
+  f_fsid:    file system id
+  f_namelen: maximum length of filenames
+  """
+  _fields_ = [
+      ("f_type",    ctypes.c_long),  # type of file system (see below)
+      ("f_bsize",   ctypes.c_long),  # optimal transfer block size
+      ("f_blocks",  ctypes.c_long),  # total data blocks in file system
+      ("f_bfree",   ctypes.c_long),  # free blocks in fs
+      ("f_bavail",  ctypes.c_long),  # free blocks avail to non-superuser
+      ("f_files",   ctypes.c_long),  # total file nodes in file system
+      ("f_ffree",   ctypes.c_long),  # free file nodes in fs
+      ("f_fsid",    ctypes.c_int*2), # file system id
+      ("f_namelen", ctypes.c_long),  # maximum length of filenames
+      # statfs_t has a bunch of extra padding, we hopefully guess large enough.
+      ("padding",   ctypes.c_char*1024),
+      ]
+
+class FilesystemInfo():
+
+    def __init__(self):
+        self._statfs = libc.statfs
+        self._statfs.argtypes = [ctypes.c_char_p, ctypes.POINTER(statfs_t)]
+        self._statfs.rettype = ctypes.c_int
+
+        self._fstatfs = libc.fstatfs
+        self._fstatfs.argtypes = [ctypes.c_int, ctypes.POINTER(statfs_t)]
+        self._fstatfs.rettype = ctypes.c_int
+
+
+    def statfs(self, path):
+      """
+      The function statfs() returns information about a mounted file system.
+      Args:
+        path: is the pathname of any file within the mounted file system.
+      Returns:
+        Returns a statfs_t object.
+      """
+      buf = statfs_t()
+      err = self._statfs(path, ctypes.byref(buf))
+      if err == -1:
+        errno = ctypes.get_errno()
+        raise OSError(errno, '%s path: %r' % (os.strerror(errno), path))
+      return buf
+
+
+    def fstatfs(self, fd):
+      """
+      The fuction fstatfs() returns information about a mounted file ssytem.
+      Args:
+        fd: A file descriptor.
+      Returns:
+        Returns a statfs_t object.
+      """
+      buf = statfs_t()
+      fileno = fd.fileno()
+      assert fileno
+      err = self._fstatfs(fileno, ctypes.byref(buf))
+      if err == -1:
+        errno = ctypes.get_errno()
+        raise OSError(errno, os.strerror(errno))
+      return buf
+
+
+    def filesystem(self, path_or_fd):
+      """
+      Get the filesystem type a file/path is on.
+      Args:
+        path_or_fd: A string path or an object which has a fileno function.
+      Returns:
+       A string name of the file system.
+      """
+      if hasattr(path_or_fd, 'fileno'):
+        buf = self.fstatfs(path_or_fd)
+      else:
+        buf = self.statfs(path_or_fd)
+      assert buf
+      f_types = Fs_types().types
+      try:
+        return f_types[buf.f_type]
+      except KeyError:
+        return "UNKNOWN"

--- a/speedcopy/fstatfs.py
+++ b/speedcopy/fstatfs.py
@@ -34,10 +34,10 @@ class Fs_types:
         "ISOFS_SUPER_MAGIC": 0x9660,
         "JFFS2_SUPER_MAGIC": 0x72b6,
         "JFS_SUPER_MAGIC": 0x3153464a,
-        "MINIX_SUPER_MAGIC": 0x137F, # orig. minix
-        "MINIX_SUPER_MAGIC2": 0x138F, # 30 char minix
-        "MINIX2_SUPER_MAGIC": 0x2468, # minix V2
-        "MINIX2_SUPER_MAGIC2": 0x2478, # minix V2, 30 char names
+        "MINIX_SUPER_MAGIC": 0x137F,  # orig. minix
+        "MINIX_SUPER_MAGIC2": 0x138F,  # 30 char minix
+        "MINIX2_SUPER_MAGIC": 0x2468,  # minix V2
+        "MINIX2_SUPER_MAGIC2": 0x2478,  # minix V2, 30 char names
         "MSDOS_SUPER_MAGIC": 0x4d44,
         "NCP_SUPER_MAGIC": 0x564c,
         "NFS_SUPER_MAGIC": 0x6969,
@@ -72,32 +72,34 @@ class Fs_types:
 
 
 class statfs_t(ctypes.Structure):
-  """
-  Describes the details about a filesystem.
+    """
+    Describes the details about a filesystem.
 
-  f_type:    type of file system (see below)
-  f_bsize:   optimal transfer block size
-  f_blocks:  total data blocks in file system
-  f_bfree:   free blocks in fs
-  f_bavail:  free blocks avail to non-superuser
-  f_files:   total file nodes in file system
-  f_ffree:   free file nodes in fs
-  f_fsid:    file system id
-  f_namelen: maximum length of filenames
-  """
-  _fields_ = [
-      ("f_type",    ctypes.c_long),  # type of file system (see below)
-      ("f_bsize",   ctypes.c_long),  # optimal transfer block size
-      ("f_blocks",  ctypes.c_long),  # total data blocks in file system
-      ("f_bfree",   ctypes.c_long),  # free blocks in fs
-      ("f_bavail",  ctypes.c_long),  # free blocks avail to non-superuser
-      ("f_files",   ctypes.c_long),  # total file nodes in file system
-      ("f_ffree",   ctypes.c_long),  # free file nodes in fs
-      ("f_fsid",    ctypes.c_int*2), # file system id
-      ("f_namelen", ctypes.c_long),  # maximum length of filenames
-      # statfs_t has a bunch of extra padding, we hopefully guess large enough.
-      ("padding",   ctypes.c_char*1024),
-      ]
+    f_type:    type of file system (see below)
+    f_bsize:   optimal transfer block size
+    f_blocks:  total data blocks in file system
+    f_bfree:   free blocks in fs
+    f_bavail:  free blocks avail to non-superuser
+    f_files:   total file nodes in file system
+    f_ffree:   free file nodes in fs
+    f_fsid:    file system id
+    f_namelen: maximum length of filenames
+    """
+    _fields_ = [
+        ("f_type",    ctypes.c_long),   # type of file system (see below)
+        ("f_bsize",   ctypes.c_long),   # optimal transfer block size
+        ("f_blocks",  ctypes.c_long),   # total data blocks in file system
+        ("f_bfree",   ctypes.c_long),   # free blocks in fs
+        ("f_bavail",  ctypes.c_long),   # free blocks avail to non-superuser
+        ("f_files",   ctypes.c_long),   # total file nodes in file system
+        ("f_ffree",   ctypes.c_long),   # free file nodes in fs
+        ("f_fsid",    ctypes.c_int*2),  # file system id
+        ("f_namelen", ctypes.c_long),   # maximum length of filenames
+        # statfs_t has a bunch of extra padding,
+        # we hopefully guess large enough.
+        ("padding",   ctypes.c_char*1024),
+    ]
+
 
 class FilesystemInfo():
 
@@ -109,7 +111,6 @@ class FilesystemInfo():
         self._fstatfs = libc.fstatfs
         self._fstatfs.argtypes = [ctypes.c_int, ctypes.POINTER(statfs_t)]
         self._fstatfs.rettype = ctypes.c_int
-
 
     def statfs(self, path):
         """

--- a/speedcopy/fstatfs.py
+++ b/speedcopy/fstatfs.py
@@ -48,6 +48,7 @@ class Fs_types:
         "REISERFS_SUPER_MAGIC": 0x52654973,
         "ROMFS_MAGIC": 0x7275,
         "SMB_SUPER_MAGIC": 0x517B,
+        "SMB2_SUPER_MAGIC": 0xfe534d42,
         "SYSV2_SUPER_MAGIC": 0x012FF7B6,
         "SYSV4_SUPER_MAGIC": 0x012FF7B5,
         "TMPFS_MAGIC": 0x01021994,

--- a/speedcopy/fstatfs.py
+++ b/speedcopy/fstatfs.py
@@ -10,63 +10,64 @@ import ctypes.util
 libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
 
 
-class Fs_types():
+class Fs_types:
     # Constants for filesystem magic
     # https://www.gnu.org/software/coreutils/filesystems.html
-    ADFS_SUPER_MAGIC       = 0xadf5
-    AFFS_SUPER_MAGIC       = 0xADFF
-    BEFS_SUPER_MAGIC       = 0x42465331
-    BFS_MAGIC              = 0x1BADFACE
-    CIFS_MAGIC_NUMBER      = 0xFF534D42
-    CODA_SUPER_MAGIC       = 0x73757245
-    COH_SUPER_MAGIC        = 0x012FF7B7
-    CRAMFS_MAGIC           = 0x28cd3d45
-    DEVFS_SUPER_MAGIC      = 0x1373
-    EFS_SUPER_MAGIC        = 0x00414A53
-    EXT_SUPER_MAGIC        = 0x137D
-    EXT2_OLD_SUPER_MAGIC   = 0xEF51
-    EXT2_SUPER_MAGIC       = 0xEF53
-    EXT3_SUPER_MAGIC       = 0xEF53
-    HFS_SUPER_MAGIC        = 0x4244
-    HPFS_SUPER_MAGIC       = 0xF995E849
-    HUGETLBFS_MAGIC        = 0x958458f6
-    ISOFS_SUPER_MAGIC      = 0x9660
-    JFFS2_SUPER_MAGIC      = 0x72b6
-    JFS_SUPER_MAGIC        = 0x3153464a
-    MINIX_SUPER_MAGIC      = 0x137F # orig. minix
-    MINIX_SUPER_MAGIC2     = 0x138F # 30 char minix
-    MINIX2_SUPER_MAGIC     = 0x2468 # minix V2
-    MINIX2_SUPER_MAGIC2    = 0x2478 # minix V2, 30 char names
-    MSDOS_SUPER_MAGIC      = 0x4d44
-    NCP_SUPER_MAGIC        = 0x564c
-    NFS_SUPER_MAGIC        = 0x6969
-    NTFS_SB_MAGIC          = 0x5346544e
-    OPENPROM_SUPER_MAGIC   = 0x9fa1
-    PROC_SUPER_MAGIC       = 0x9fa0
-    QNX4_SUPER_MAGIC       = 0x002f
-    REISERFS_SUPER_MAGIC   = 0x52654973
-    ROMFS_MAGIC            = 0x7275
-    SMB_SUPER_MAGIC        = 0x517B
-    SYSV2_SUPER_MAGIC      = 0x012FF7B6
-    SYSV4_SUPER_MAGIC      = 0x012FF7B5
-    TMPFS_MAGIC            = 0x01021994
-    UDF_SUPER_MAGIC        = 0x15013346
-    UFS_MAGIC              = 0x00011954
-    USBDEVICE_SUPER_MAGIC  = 0x9fa2
-    VXFS_SUPER_MAGIC       = 0xa501FCF5
-    XENIX_SUPER_MAGIC      = 0x012FF7B4
-    XFS_SUPER_MAGIC        = 0x58465342
-    _XIAFS_SUPER_MAGIC     = 0x012FD16D
+    filesystems = {
+        "ADFS_SUPER_MAGIC": 0xadf5,
+        "AFFS_SUPER_MAGIC": 0xADFF,
+        "BEFS_SUPER_MAGIC": 0x42465331,
+        "BFS_MAGIC": 0x1BADFACE,
+        "CIFS_MAGIC_NUMBER": 0xFF534D42,
+        "CODA_SUPER_MAGIC": 0x73757245,
+        "COH_SUPER_MAGIC": 0x012FF7B7,
+        "CRAMFS_MAGIC": 0x28cd3d45,
+        "DEVFS_SUPER_MAGIC": 0x1373,
+        "EFS_SUPER_MAGIC": 0x00414A53,
+        "EXT_SUPER_MAGIC": 0x137D,
+        "EXT2_OLD_SUPER_MAGIC": 0xEF51,
+        "EXT2_SUPER_MAGIC": 0xEF53,
+        "EXT3_SUPER_MAGIC": 0xEF53,
+        "HFS_SUPER_MAGIC": 0x4244,
+        "HPFS_SUPER_MAGIC": 0xF995E849,
+        "HUGETLBFS_MAGIC": 0x958458f6,
+        "ISOFS_SUPER_MAGIC": 0x9660,
+        "JFFS2_SUPER_MAGIC": 0x72b6,
+        "JFS_SUPER_MAGIC": 0x3153464a,
+        "MINIX_SUPER_MAGIC": 0x137F, # orig. minix
+        "MINIX_SUPER_MAGIC2": 0x138F, # 30 char minix
+        "MINIX2_SUPER_MAGIC": 0x2468, # minix V2
+        "MINIX2_SUPER_MAGIC2": 0x2478, # minix V2, 30 char names
+        "MSDOS_SUPER_MAGIC": 0x4d44,
+        "NCP_SUPER_MAGIC": 0x564c,
+        "NFS_SUPER_MAGIC": 0x6969,
+        "NTFS_SB_MAGIC": 0x5346544e,
+        "OPENPROM_SUPER_MAGIC": 0x9fa1,
+        "PROC_SUPER_MAGIC": 0x9fa0,
+        "QNX4_SUPER_MAGIC": 0x002f,
+        "REISERFS_SUPER_MAGIC": 0x52654973,
+        "ROMFS_MAGIC": 0x7275,
+        "SMB_SUPER_MAGIC": 0x517B,
+        "SYSV2_SUPER_MAGIC": 0x012FF7B6,
+        "SYSV4_SUPER_MAGIC": 0x012FF7B5,
+        "TMPFS_MAGIC": 0x01021994,
+        "UDF_SUPER_MAGIC": 0x15013346,
+        "UFS_MAGIC": 0x00011954,
+        "USBDEVICE_SUPER_MAGIC": 0x9fa2,
+        "VXFS_SUPER_MAGIC": 0xa501FCF5,
+        "XENIX_SUPER_MAGIC": 0x012FF7B4,
+        "XFS_SUPER_MAGIC": 0x58465342,
+        "_XIAFS_SUPER_MAGIC": 0x012FD16D
+    }
 
     types = {}
 
     def __init__(self):
-
-        for name in self.__dict__:
+        for name, value in self.filesystems.items():
             if name.endswith('MAGIC'):
                 hname = name[:-6]
                 hname = hname.replace('_SUPER', '')
-                _types[eval(name)] = hname
+                self.types[value] = hname
 
 
 class statfs_t(ctypes.Structure):
@@ -110,54 +111,53 @@ class FilesystemInfo():
 
 
     def statfs(self, path):
-      """
-      The function statfs() returns information about a mounted file system.
-      Args:
-        path: is the pathname of any file within the mounted file system.
-      Returns:
-        Returns a statfs_t object.
-      """
-      buf = statfs_t()
-      err = self._statfs(path, ctypes.byref(buf))
-      if err == -1:
-        errno = ctypes.get_errno()
-        raise OSError(errno, '%s path: %r' % (os.strerror(errno), path))
-      return buf
-
+        """
+        The function statfs() returns information about a mounted file system.
+        Args:
+            path: is the pathname of any file within the mounted file system.
+        Returns:
+            Returns a statfs_t object.
+        """
+        buf = statfs_t()
+        err = self._statfs(path, ctypes.byref(buf))
+        if err == -1:
+            errno = ctypes.get_errno()
+            raise OSError(errno, '%s path: %r' % (os.strerror(errno), path))
+        return buf
 
     def fstatfs(self, fd):
-      """
-      The fuction fstatfs() returns information about a mounted file ssytem.
-      Args:
-        fd: A file descriptor.
-      Returns:
-        Returns a statfs_t object.
-      """
-      buf = statfs_t()
-      fileno = fd.fileno()
-      assert fileno
-      err = self._fstatfs(fileno, ctypes.byref(buf))
-      if err == -1:
-        errno = ctypes.get_errno()
-        raise OSError(errno, os.strerror(errno))
-      return buf
-
+        """
+        The fuction fstatfs() returns information about a mounted file ssytem.
+        Args:
+            fd: A file descriptor.
+        Returns:
+            Returns a statfs_t object.
+        """
+        buf = statfs_t()
+        fileno = fd.fileno()
+        assert fileno
+        err = self._fstatfs(fileno, ctypes.byref(buf))
+        if err == -1:
+            errno = ctypes.get_errno()
+            raise OSError(errno, os.strerror(errno))
+        return buf
 
     def filesystem(self, path_or_fd):
-      """
-      Get the filesystem type a file/path is on.
-      Args:
-        path_or_fd: A string path or an object which has a fileno function.
-      Returns:
-       A string name of the file system.
-      """
-      if hasattr(path_or_fd, 'fileno'):
-        buf = self.fstatfs(path_or_fd)
-      else:
-        buf = self.statfs(path_or_fd)
-      assert buf
-      f_types = Fs_types().types
-      try:
-        return f_types[buf.f_type]
-      except KeyError:
-        return "UNKNOWN"
+        """
+        Get the filesystem type a file/path is on.
+        Args:
+            path_or_fd: A string path or an object which has a fileno function.
+        Returns:
+            A string name of the file system.
+        """
+        if hasattr(path_or_fd, 'fileno'):
+            buf = self.fstatfs(path_or_fd)
+        else:
+            buf = self.statfs(path_or_fd)
+
+        assert buf
+        f_types = Fs_types().types
+        try:
+            return f_types[buf.f_type]
+        except KeyError:
+            return "UNKNOWN"

--- a/speedcopy/version.py
+++ b/speedcopy/version.py
@@ -1,6 +1,6 @@
-VERSION_MAJOR = 1
+VERSION_MAJOR = 2
 VERSION_MINOR = 0
-VERSION_PATCH = 4
+VERSION_PATCH = 0
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/tests/test_speedcopy.py
+++ b/tests/test_speedcopy.py
@@ -2,6 +2,7 @@ import shutil
 import speedcopy
 import os
 
+speedcopy.SPEEDCOPY_DEBUG = True
 
 def setup_function(function):
     speedcopy.patch_copyfile()

--- a/tests/test_speedcopy.py
+++ b/tests/test_speedcopy.py
@@ -4,6 +4,7 @@ import os
 
 speedcopy.SPEEDCOPY_DEBUG = True
 
+
 def setup_function(function):
     speedcopy.patch_copyfile()
 


### PR DESCRIPTION
This rewrites speedcopy to use system native calls at first, then fallback to more generic one.

### Windows
On windows we user [**CopyFileW**](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-copyfilew) - this should enable server-side copy on modern windows

### Linux
Linux is using special *ioctl* call `CIFS_IOC_COPYCHUNK_FILE` to enable server-side copy. It only works on SMB2 and CIFS filesystems so we first check that both source and destination is on those filesystems before issuing ioctl. Fallback is to [**os.sendfile**](https://docs.python.org/3/library/os.html#os.sendfile) and then to default python way.

This should be much faster on windows then using subprocess of `xcopy` and linux is finally supported.

Collection of benchmark data is underway ...