### PR TITLE
compatibility for windws <= 7, docstrings and few fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
-from setuptools import setup, find_packages
+# -*- coding: utf-8 -*-
+"""Metadata file."""
+from setuptools import setup
 import os
 import imp
 from io import open
@@ -22,20 +24,23 @@ classifiers = [
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Topic :: Software Development :: Libraries :: Python Modules",
-	"Topic :: System :: Filesystems"
+    "Topic :: System :: Filesystems"
 
 ]
 
 setup(name='speedcopy',
       version=version,
-      description=('Windows xcopy patch for shutil.copyfile'
-                   ', based on pyfastcopy'),
+      description=('Replacement or alternative for python copyfile()'
+                   'utilizing server side copy on network shares for faster'
+                   'copying.'),
       author='Ondrej Samohel',
       author_email='annatar@annatar.net',
       url='https://github.com/antirotor/speedcopy',
       long_description=long_description,
       long_description_content_type='text/markdown',
-	  packages=['speedcopy'],
-	  classifiers=classifiers
+      packages=['speedcopy'],
+      classifiers=classifiers,
+      tests_require=['pytest'],
       )

--- a/speedcopy/fstatfs.py
+++ b/speedcopy/fstatfs.py
@@ -1,6 +1,9 @@
-"""
-python fstatfs implementation taken from:
+# -*- coding: utf-8 -*-
+"""Python fstatfs implementation.
+
+Taken from:
 https://github.com/mithro/rcfiles
+
 """
 import os
 import ctypes
@@ -11,8 +14,12 @@ libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
 
 
 class Fs_types:
-    # Constants for filesystem magic
-    # https://www.gnu.org/software/coreutils/filesystems.html
+    """Constants for filesystem magic.
+
+    See:
+        https://www.gnu.org/software/coreutils/filesystems.html
+    """
+
     filesystems = {
         "ADFS_SUPER_MAGIC": 0xadf5,
         "AFFS_SUPER_MAGIC": 0xADFF,
@@ -64,6 +71,7 @@ class Fs_types:
     types = {}
 
     def __init__(self):
+        """Remove ``MAGIC`` and ``SUPER`` postfixes."""
         for name, value in self.filesystems.items():
             if name.endswith('MAGIC'):
                 hname = name[:-6]
@@ -72,19 +80,20 @@ class Fs_types:
 
 
 class statfs_t(ctypes.Structure):
-    """
-    Describes the details about a filesystem.
+    """Describes the details about a filesystem.
 
-    f_type:    type of file system (see below)
-    f_bsize:   optimal transfer block size
-    f_blocks:  total data blocks in file system
-    f_bfree:   free blocks in fs
-    f_bavail:  free blocks avail to non-superuser
-    f_files:   total file nodes in file system
-    f_ffree:   free file nodes in fs
-    f_fsid:    file system id
-    f_namelen: maximum length of filenames
+    Attributes:
+        f_type:    type of file system (see below)
+        f_bsize:   optimal transfer block size
+        f_blocks:  total data blocks in file system
+        f_bfree:   free blocks in fs
+        f_bavail:  free blocks avail to non-superuser
+        f_files:   total file nodes in file system
+        f_ffree:   free file nodes in fs
+        f_fsid:    file system id
+        f_namelen: maximum length of filenames
     """
+
     _fields_ = [
         ("f_type",    ctypes.c_long),   # type of file system (see below)
         ("f_bsize",   ctypes.c_long),   # optimal transfer block size
@@ -102,8 +111,10 @@ class statfs_t(ctypes.Structure):
 
 
 class FilesystemInfo():
+    """Get filesystem info."""
 
     def __init__(self):
+        """Prepare system calls."""
         self._statfs = libc.statfs
         self._statfs.argtypes = [ctypes.c_char_p, ctypes.POINTER(statfs_t)]
         self._statfs.rettype = ctypes.c_int
@@ -113,12 +124,15 @@ class FilesystemInfo():
         self._fstatfs.rettype = ctypes.c_int
 
     def statfs(self, path):
-        """
-        The function statfs() returns information about a mounted file system.
+        """Get information about mounted file system by path.
+
         Args:
-            path: is the pathname of any file within the mounted file system.
+            path (str): is the pathname of any file within
+                        the mounted file system.
+
         Returns:
             Returns a statfs_t object.
+
         """
         buf = statfs_t()
         err = self._statfs(path, ctypes.byref(buf))
@@ -128,12 +142,13 @@ class FilesystemInfo():
         return buf
 
     def fstatfs(self, fd):
-        """
-        The fuction fstatfs() returns information about a mounted file ssytem.
+        """Get information about mounted file system by file descriptor.
+
         Args:
             fd: A file descriptor.
         Returns:
             Returns a statfs_t object.
+
         """
         buf = statfs_t()
         fileno = fd.fileno()
@@ -145,10 +160,11 @@ class FilesystemInfo():
         return buf
 
     def filesystem(self, path_or_fd):
-        """
-        Get the filesystem type a file/path is on.
+        """Get the filesystem type a file/path is on.
+
         Args:
-            path_or_fd: A string path or an object which has a fileno function.
+            path_or_fd (str or IOBase): A string path or an object which has
+                                        a :meth:`IOBase.fileno()` function.
         Returns:
             A string name of the file system.
         """

--- a/speedcopy/version.py
+++ b/speedcopy/version.py
@@ -1,6 +1,8 @@
+# -*- coding: utf-8 -*-
+"""Version definition."""
 VERSION_MAJOR = 2
-VERSION_MINOR = 0
-VERSION_PATCH = 1
+VERSION_MINOR = 1
+VERSION_PATCH = 0
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/tests/test_speedcopy.py
+++ b/tests/test_speedcopy.py
@@ -58,7 +58,7 @@ def test_errors(tmpdir):
     src = tmpdir.join("source")
     dst = tmpdir.join("destination")
 
-    with pytest.raises(IOError):
+    with pytest.raises((IOError, OSError)):
         shutil.copyfile(str(src), str(dst))
 
 

--- a/tests/test_speedcopy.py
+++ b/tests/test_speedcopy.py
@@ -1,20 +1,28 @@
+# -*- coding: utf-8 -*-
+"""Tests for speedcopy."""
+
 import shutil
 import speedcopy
 import os
+import pytest
+
 
 speedcopy.SPEEDCOPY_DEBUG = True
 _FILE_SIZE = 5 * 1024 * 1024
 
 
 def setup_function(function):
+    """Test setup."""
     speedcopy.patch_copyfile()
 
 
 def teadown_function(function):
+    """Test teardown."""
     speedcopy.unpatch_copyfile()
 
 
 def test_copy_abs(tmpdir):
+    """Test copy from absolute paths."""
     src = tmpdir.join("source")
     dst = tmpdir.join("destination")
     with open(str(src), "wb") as f:
@@ -27,6 +35,7 @@ def test_copy_abs(tmpdir):
 
 
 def test_copy_rel(tmpdir):
+    """Test copy from relative paths."""
     cwd = os.getcwd()
     os.chdir(str(tmpdir))
 
@@ -44,10 +53,21 @@ def test_copy_rel(tmpdir):
         os.chdir(cwd)
 
 
+def test_errors(tmpdir):
+    """Exception IOError should be raised if file doesn't exist."""
+    src = tmpdir.join("source")
+    dst = tmpdir.join("destination")
+
+    with pytest.raises(IOError):
+        shutil.copyfile(str(src), str(dst))
+
+
 def test_patch():
+    """Test if copyfile is patched."""
     assert shutil.copyfile == speedcopy.copyfile
 
 
 def test_unpatch():
+    """Test if copyfile is restored."""
     speedcopy.unpatch_copyfile()
     assert shutil.copyfile == shutil._orig_copyfile


### PR DESCRIPTION
adding compatibility for windows 7 and older using `CopyFileW` instead of `CopyFile2`. Server side copy will then not work. Fixed error detection (copyfile return 0 if some error occured). Returned error also contains message formatted by native windows call. Added docstrings. 