### PR TITLE
fix python 2 support in poetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ venv.bak/
 
 # poetry
 .poetry/
+.idea/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ description = ""
 authors = ["Ondrej Samohel <annatar@annatar.net>"]
 
 [tool.poetry.dependencies]
-python = "^3.6"
-pysendfile = {version = "^2.0.1", markers = "sys_platform == 'linux' or sys_platform == 'darwin'"}
+python = ">=2.7"
+pysendfile = {version = "^2.0.1", markers = "sys_platform == 'linux' or sys_platform == 'darwin'", python = "~2.7"}
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
This PR is fixing support for python 2.7 and how `pysendfile` dependency is handled.