### PR TITLE
Fix pysendfile specification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Ondrej Samohel <annatar@annatar.net>"]
 
 [tool.poetry.dependencies]
 python = ">=2.7"
-pysendfile = {version = "^2.0.1", markers = "sys_platform == 'linux' or sys_platform == 'darwin'", python = "~2.7"}
+pysendfile = {version = "^2.0.1", markers = "(sys_platform == 'linux' or sys_platform == 'darwin') and python_version ~= '2.7'"}
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Poetry doesn't seem to (properly) simultaneously support [Python restricted dependencies](https://python-poetry.org/docs/dependency-specification/#python-restricted-dependencies) and [environment markers](https://python-poetry.org/docs/dependency-specification/#using-environment-markers). I kept getting inconsistent results depending on my environment.

This commit reformulates the Python restricted dependency within the environment marker expression, and is consistent with the Poetry documentation.